### PR TITLE
[Feature] Iterator stages (flattener)

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+format_code_in_doc_comments = true
+wrap_comments = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 0.2.1 (Jan 2, 2024)
+
+Primary feature: added `flattener` stage. Additionally, made various tweaks to code and documentation.
+
+**Feature(s):**
+* Add `PipelineBuilder::with_flattener`.
+* Add "Getting Started" section to documentation.
+* Add well-defined error messages for `PipelineBuilder::build`, including a new error when there is
+  no producer stage.
+
+**Fixes:**
+* Update link to docs in `README.md` to point to latest version.
+* Fixed mal-formatted documentation in `PipelineBuilder`.
+* Use `Drop` trait for decrement internal synchronizer in case of task error.
+* Use pipe names as their IDs, as their uniqueness is an invariant to the pipeline builder's logic.
+
 ## 0.2.0 (Dec 31, 2023)
 
 Complete redesign of how pipelines are built. Using the same understanding of how to manage and run workers/tasks,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-pipes"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jake Biewer <biewers2@gmail.com>"]
 edition = "2021"
 rust-version = "1.63.0" # According to `$ cargo msrv`

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For information on getting started with Async Pipes, see the [documentation](#do
 
 ## Documentation
 
-[Async Pipes - Docs.rs](https://docs.rs/async-pipes/0.1.0/async_pipes/)
+[Async Pipes - Docs.rs](https://docs.rs/async-pipes/latest/async_pipes/)
 
 #### Simple, Linear Pipeline Example
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,6 +3,18 @@ use std::sync::Arc;
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::sync;
+use crate::sync::Synchronizer;
+
+pub struct Consumed {
+    id: String,
+    sync: Arc<Synchronizer>,
+}
+
+impl Drop for Consumed {
+    fn drop(&mut self) {
+        self.sync.ended(&self.id)
+    }
+}
 
 /// Defines an end to a pipe that allows data to be received from.
 #[derive(Debug)]
@@ -32,21 +44,24 @@ impl<T> PipeReader<T> {
     ///
     /// We use a callback function here so it can be passed and called in the task definition
     /// without having to give ownership of this reader to the task definition.
-    pub fn consumed_callback(&self) -> impl FnOnce() {
-        let id = self.pipe_id.clone();
-        let sync = self.synchronizer.clone();
-        move || sync.ended(id)
-    }
 
     /// Receive the next value from the inner receiver.
-    pub async fn read(&mut self) -> Option<T> {
-        self.rx.recv().await
+    pub async fn read(&mut self) -> Option<(T, Consumed)> {
+        self.rx.recv().await.map(|v| (v, self.consumed()))
+    }
+
+    fn consumed(&self) -> Consumed {
+        Consumed {
+            id: self.pipe_id.clone(),
+            sync: self.synchronizer.clone(),
+        }
     }
 }
 
 /// Defines an end to a pipe that allows data to be sent through.
 #[derive(Debug)]
 pub struct PipeWriter<T> {
+    name: String,
     pipe_id: String,
     synchronizer: Arc<sync::Synchronizer>,
     tx: Sender<T>,
@@ -57,6 +72,7 @@ pub struct PipeWriter<T> {
 impl<T> Clone for PipeWriter<T> {
     fn clone(&self) -> Self {
         Self {
+            name: self.name.clone(),
             pipe_id: self.pipe_id.clone(),
             synchronizer: self.synchronizer.clone(),
             tx: self.tx.clone(),
@@ -66,11 +82,13 @@ impl<T> Clone for PipeWriter<T> {
 
 impl<T> PipeWriter<T> {
     pub fn new(
+        name: impl Into<String>,
         pipe_id: impl Into<String>,
         synchronizer: Arc<sync::Synchronizer>,
         output_tx: Sender<T>,
     ) -> Self {
         Self {
+            name: name.into(),
             pipe_id: pipe_id.into(),
             synchronizer,
             tx: output_tx,
@@ -96,21 +114,24 @@ mod tests {
 
     use crate::sync::Synchronizer;
 
-    #[test]
-    fn test_input_consumed_callback_updates_sync() {
+    #[tokio::test]
+    async fn test_read_consumed_updates_sync_on_drop() {
         let id = "pipe-id";
         let mut sync = Synchronizer::default();
         sync.register(id);
         sync.started_many(id, 4);
 
         let sync = Arc::new(sync);
-        let (_, rx) = channel::<()>(1);
-        let input = PipeReader::new(id, sync.clone(), rx);
+        let (tx, rx) = channel::<()>(1);
 
-        let callback = input.consumed_callback();
+        let mut input = PipeReader::new(id, sync.clone(), rx);
 
-        assert_eq!(sync.get(id), 4);
-        callback();
+        tx.send(()).await.unwrap();
+
+        {
+            let (_, _c) = input.read().await.unwrap();
+            assert_eq!(sync.get(id), 4);
+        }
         assert_eq!(sync.get(id), 3);
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use tokio::sync::mpsc::{Receiver, Sender};
 
-use crate::sync;
 use crate::sync::Synchronizer;
 
 pub struct Consumed {
@@ -20,14 +19,14 @@ impl Drop for Consumed {
 #[derive(Debug)]
 pub struct PipeReader<T> {
     pipe_id: String,
-    synchronizer: Arc<sync::Synchronizer>,
+    synchronizer: Arc<Synchronizer>,
     rx: Receiver<T>,
 }
 
 impl<T> PipeReader<T> {
     pub fn new(
         pipe_id: impl Into<String>,
-        synchronizer: Arc<sync::Synchronizer>,
+        synchronizer: Arc<Synchronizer>,
         input_rx: Receiver<T>,
     ) -> Self {
         Self {
@@ -61,9 +60,8 @@ impl<T> PipeReader<T> {
 /// Defines an end to a pipe that allows data to be sent through.
 #[derive(Debug)]
 pub struct PipeWriter<T> {
-    name: String,
     pipe_id: String,
-    synchronizer: Arc<sync::Synchronizer>,
+    synchronizer: Arc<Synchronizer>,
     tx: Sender<T>,
 }
 
@@ -72,7 +70,6 @@ pub struct PipeWriter<T> {
 impl<T> Clone for PipeWriter<T> {
     fn clone(&self) -> Self {
         Self {
-            name: self.name.clone(),
             pipe_id: self.pipe_id.clone(),
             synchronizer: self.synchronizer.clone(),
             tx: self.tx.clone(),
@@ -82,13 +79,11 @@ impl<T> Clone for PipeWriter<T> {
 
 impl<T> PipeWriter<T> {
     pub fn new(
-        name: impl Into<String>,
         pipe_id: impl Into<String>,
-        synchronizer: Arc<sync::Synchronizer>,
+        synchronizer: Arc<Synchronizer>,
         output_tx: Sender<T>,
     ) -> Self {
         Self {
-            name: name.into(),
             pipe_id: pipe_id.into(),
             synchronizer,
             tx: output_tx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,14 +138,6 @@ fn new_id() -> String {
 /// Useful for interrupting the natural workflow to tell it something.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 enum StageWorkerSignal {
-    /// For now, this is a placeholder signal and marked as dead code.
-    ///
-    /// This is to avoid a compiler error in [Pipeline::new_stage_worker] where the loop
-    /// complains about never having another iteration due to all other branches breaking
-    /// within the `select!`.
-    #[allow(dead_code)]
-    Ping,
-
     /// Used to tell stage workers to finish immediately without waiting for remaining tasks to end.
     Terminate,
 }
@@ -156,7 +148,6 @@ impl Display for StageWorkerSignal {
             f,
             "{}",
             match self {
-                Self::Ping => "SIGPING",
                 Self::Terminate => "SIGTERM",
             }
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,10 +129,6 @@ mod io;
 mod pipeline;
 mod sync;
 
-fn new_id() -> String {
-    uuid::Uuid::new_v4().to_string()
-}
-
 /// Signals sent to stage workers.
 ///
 /// Useful for interrupting the natural workflow to tell it something.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,10 @@
 //! * [PipelineBuilder::with_stage]
 //! * [PipelineBuilder::with_branching_stage]
 //!
+//! ### Utility
+//! This is an intermediate stage in the pipeline that can be used to do common operations on data between pipes.
+//! * [PipelineBuilder::with_flattener]
+//!
 //! # Stage Variants
 //!
 //! ### Branching (1 input, N outputs)

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -318,7 +318,7 @@ impl PipelineBuilder {
     /// pipe it is receiving from is closed.
     ///
     /// * If the user-defined task function returns [None], nothing will be done.
-    /// * If it returns [Some], the inner value ([Vec<Option<BoxedAnySend>>]) will have the
+    /// * If it returns [Some], the inner value ([`Vec<Option<BoxedAnySend>>`]) will have the
     ///   following applied to each output option:
     ///     * If [Some] is specified, the inner value will be sent to the corresponding pipe.
     ///     * If [None] is specified, nothing will be sent.
@@ -371,7 +371,7 @@ impl PipelineBuilder {
     /// This is useful if you have a pipe that produces a list of values in a single task execution,
     /// but you want to use it as input to another stage that takes only the individual values.
     ///
-    /// The generic parameter [It] is used by the pipeline builder to know what concrete type to
+    /// The generic parameter is used by the pipeline builder to know what concrete type to
     /// cast the value to, which mean turbofish syntax will be needed to specify what the iterator
     /// type of that pipe is, for example:
     /// `Pipeline::builder().with_flattener::<Vec<u8>>("data", "bytes")`
@@ -822,7 +822,7 @@ impl Pipeline {
     ///      pipeline)
     ///
     /// Step 1 implies that if the producers never finish, the pipeline will run forever. See
-    /// [Pipeline::register_producer] for more info.
+    /// [PipelineBuilder::with_producer] for more info.
     pub async fn wait(mut self) {
         let workers_to_progress = Arc::new(Mutex::new(self.workers));
         let workers_to_finish = workers_to_progress.clone();

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::{Acquire, SeqCst};
+use std::sync::atomic::Ordering::{AcqRel, Acquire};
 
 /// A generic data structure to synchronize tasks being done among multiple threads.
 ///
-/// The IDs of the tasks must be registered in order to be tracked. Tasks can be marked as "started" or
-/// "ended" which increments and decrements (respectively) the respective task ID counter. A synchronizer
-/// is considered "complete" if all task ID counters are zero.
+/// The IDs of the tasks must be registered in order to be tracked. Tasks can be marked as "started"
+/// or "ended" which increments and decrements (respectively) the respective task ID counter. A
+/// synchronizer is considered "complete" if all task ID counters are zero.
 #[derive(Default, Debug)]
 pub struct Synchronizer {
     /// Maintain a total count to easily check if all task ID counters are zero
@@ -25,8 +25,8 @@ impl Synchronizer {
 
     pub fn started_many<S: AsRef<str>>(&self, id: S, n: usize) {
         if let Some(count) = self.counts.get(id.as_ref()) {
-            count.fetch_add(n, SeqCst);
-            self.total_count.fetch_add(n, SeqCst);
+            count.fetch_add(n, AcqRel);
+            self.total_count.fetch_add(n, AcqRel);
         }
     }
 
@@ -36,8 +36,8 @@ impl Synchronizer {
 
     pub fn ended_many<S: AsRef<str>>(&self, id: S, n: usize) {
         if let Some(count) = self.counts.get(id.as_ref()) {
-            count.fetch_sub(n, SeqCst);
-            self.total_count.fetch_sub(n, SeqCst);
+            count.fetch_sub(n, AcqRel);
+            self.total_count.fetch_sub(n, AcqRel);
         }
     }
 


### PR DESCRIPTION
Add support for iterator-based stages, where the value read in from a pipe is an iterator.
Additionally make some code cleanup changes and some documentation additions and fixes.

* Add `PipelineBuilder::with_flattener`
* Update documentation link in README to point to latest version
* Utilize `Drop` trait for marking input as "consumed" for synchronizer
* Remove dead code `StageWorkerSignal::Ping`
* Use pipe names as IDs, as their uniqueness is an invariant to the library's core functionality
* Fix mal-formatted documentation in `PipelineBuilder`
* Create common worker definition functions in `PipelineBuilder`
* Add `Getting Started` docs
* Clarify errors returned by `PipelineBuilder::build`