### PR TITLE
[Enhance] Use unbounded buffer for flattener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1 (Feb 4, 2024)
+**Fixes:**
+* Cyclic pipelines that use a flatten stage were found to deadlock due to all  the buffers being
+  full. Now, flatten stages use an unbounded channel for pipes so this doesn't happen.
+
 ## 0.3.0 (Jan 13, 2024)
 **Feature(s):**
 * Add `WorkerOptions` struct

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-pipes"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Jake Biewer <biewers2@gmail.com>"]
 edition = "2021"
 rust-version = "1.74.1" # According to `$ cargo msrv`

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -85,6 +85,7 @@ impl WorkerOptions {
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 struct ValidWorkerOptions {
+    unbounded_buffer: bool,
     reader_buffer_size: NonZeroUsize,
     max_task_count: NonZeroUsize,
 }
@@ -94,6 +95,7 @@ impl TryFrom<WorkerOptions> for ValidWorkerOptions {
 
     fn try_from(value: WorkerOptions) -> Result<Self, Self::Error> {
         Ok(Self {
+            unbounded_buffer: false,
             reader_buffer_size: NonZeroUsize::new(value.pipe_buffer_size)
                 .ok_or("reader buffer size must not be zero")?,
             max_task_count: NonZeroUsize::new(value.max_task_count)
@@ -379,7 +381,7 @@ impl Pipeline {
         };
 
         // Effectively, make progress until all producers are done.
-        // We do this to prevent the synchronizer from causing the pipeline to shutdown too early.
+        // We do this to prevent the synchronizer from causing the pipeline to shut down too early.
         select! {
             _ = wait_for_producers => {},
             _ = wait_for_workers(workers_to_progress),

--- a/src/pipeline/workers.rs
+++ b/src/pipeline/workers.rs
@@ -91,7 +91,7 @@ pub async fn new_detached_flattener(
 
 /// Creates a new worker that runs tasks synchronously.
 ///
-/// We could use the multi-task worker and limit the number of active tasks to one, but this
+/// We could use the multitask worker and limit the number of active tasks to one, but this
 /// reduces the overhead of spawning tasks and waiting for them to finish.
 async fn new_detached_single_task_worker<F, Fut>(
     mut reader: PipeReader<BoxedAnySend>,

--- a/tests/enron_test.rs
+++ b/tests/enron_test.rs
@@ -1,0 +1,2 @@
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+async fn test_map_reduce_on_enron_dataset() {}


### PR DESCRIPTION
Cyclic pipelines using a flatten stage were found to deadlock due to all the buffers being full. This PR fixes that by allowing the flatten stage to use an unbounded buffer.